### PR TITLE
Automated NPM install and running server.js in background

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ machine = [
     config:    "vm_config.sh",
     ip:        "172.69.69.69",
     synchost:  ".",
-    syncguest: "/bulochnik",
+    syncguest: "/bulochnik.com",
   }
 ]
 

--- a/vm_config.sh
+++ b/vm_config.sh
@@ -4,5 +4,11 @@ apt-get update -qqy
 apt-get install -qqy git
 apt-get install -qqy build-essential
 curl -sL https://deb.nodesource.com/setup_5.x | bash
-apt-get isntall -qqy nodejs
+apt-get install -qqy nodejs
+
 npm install -g bower
+npm install -g forever
+
+cd /bulochnik.com
+forever start server.js
+echo "Forever is now running server.js on 172.69.69.69:3000" > /etc/motd

--- a/vm_config.sh
+++ b/vm_config.sh
@@ -10,5 +10,6 @@ npm install -g bower
 npm install -g forever
 
 cd /bulochnik.com
+npm install
 forever start server.js
 echo "Forever is now running server.js on 172.69.69.69:3000" > /etc/motd


### PR DESCRIPTION
Added a few lines to the shell provisioner to automate the local installation of NPM dependencies in the add directory. Also global installation of NPM item "Forever", which is used to run the Node server as a background process automatically on machine boot. Minor change, renamed VM project sync folder to maintain structure consistent with the end goal.